### PR TITLE
Bump to 3.34 & remove dconf access

### DIFF
--- a/org.gnome.zbrown.Palette.json
+++ b/org.gnome.zbrown.Palette.json
@@ -1,18 +1,14 @@
 {
     "app-id": "org.gnome.zbrown.Palette",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.32",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "org.gnome.zbrown.Palette",
     "finish-args": [
         "--share=ipc",
         "--device=dri",
         "--socket=fallback-x11",
-        "--socket=wayland",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--socket=wayland"
     ],
     "modules": [
         {


### PR DESCRIPTION
The app didn't need dconf at all.